### PR TITLE
Fix: bloodmoon command: negative day

### DIFF
--- a/src/commands/bloodmoon.js
+++ b/src/commands/bloodmoon.js
@@ -18,7 +18,7 @@ export const bloodmoonRes = {
     const guildid = interaction.member.guild.id
 
     const day = interaction.options.get('day').value
-    
+
     console.log(`${username} on ${guildname} (${guildid}) used /bloodmoon day:${day}`)
 
     if (day < 1) {

--- a/src/commands/bloodmoon.js
+++ b/src/commands/bloodmoon.js
@@ -17,11 +17,17 @@ export const bloodmoonRes = {
     const guildname = interaction.member.guild.name
     const guildid = interaction.member.guild.id
 
-    console.log(`${username} on ${guildname} (${guildid}) used (/) command bloodmoon`)
+    const day = interaction.options.get('day').value
+    
+    console.log(`${username} on ${guildname} (${guildid}) used /bloodmoon day:${day}`)
 
-    const today = interaction.options.get('day').value
-    const til = 7 - (today - (Math.floor(today / 7) * 7))
-    const onDay = today + til
+    if (day < 1) {
+      await interaction.reply(`Why is your server on day ${day}?`)
+      return
+    }
+
+    const til = 7 - (day - (Math.floor(day / 7) * 7))
+    const onDay = day + til
 
     if (til === 7) {
       await interaction.reply('Bloodmoon tonight, hold on to your butts!')


### PR DESCRIPTION
Fixes responding with the wrong day when given a negative day number for bloodmoon command. Now responds with cheekiness and returns out of the function.