### PR TITLE
Fix: typos: 7days2die, bloodmoon

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 # <span style="font-size: 64px;"><img src="icons/bhava-icon.png" alt="Bhavachakra, the wheel of becoming" width="44"/>Bhava</span>
 
-Bhava is an all-rounder Discord bot.
+Bhava is an all-rounder Discord bot
 
 ## Commands
 
 **Misc**
 
-`/ping` Pings the bot to check if it's responding.
+`/ping` Pings the bot to check if it's responding
 
-`/bloodmoon` *`days` Calculates when the next bloodmoon will rise in 7 Days to Die
+`/bloodmoon` *`days` Calculates when the next blood moon will rise in 7 Days to Die
 
 *= Required Option
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Bhava is an all-rounder Discord bot.
 
 `/ping` Pings the bot to check if it's responding.
 
-`/bloodmoon` *`days` Calculates when the next bloodmoon will rise in 7Days2Die
+`/bloodmoon` *`days` Calculates when the next bloodmoon will rise in 7 Days to Die
 
 *= Required Option
 

--- a/src/commands/bloodmoon.js
+++ b/src/commands/bloodmoon.js
@@ -1,6 +1,6 @@
 export const bloodmoon = {
   name: 'bloodmoon',
-  description: 'Calculates when the next bloodmoon will rise in 7 Days to Die',
+  description: 'Calculates when the next blood moon will rise in 7 Days to Die',
   options: [
     {
       name: 'day',
@@ -25,10 +25,10 @@ export const bloodmoonRes = {
     const bloodmoonNumber = Math.ceil(day / 7)
 
     if (!daysRemaining) {
-      await interaction.reply(`Bloodmoon number ${bloodmoonNumber} tonight, HOLD ON TO YOUR BUTTS!`)
+      await interaction.reply(`Blood moon number ${bloodmoonNumber} tonight, HOLD ON TO YOUR BUTTS!`)
       return
     }
     const s = daysRemaining === 1 ? '' : 's'
-    await interaction.reply(`Bloodmoon number ${bloodmoonNumber} in ${daysRemaining} day${s}, on day ${nextBloodmoon}`)
+    await interaction.reply(`Blood moon number ${bloodmoonNumber} in ${daysRemaining} day${s}, on day ${nextBloodmoon}`)
   }
 }

--- a/src/commands/bloodmoon.js
+++ b/src/commands/bloodmoon.js
@@ -1,6 +1,6 @@
 export const bloodmoon = {
   name: 'bloodmoon',
-  description: 'Calculates when the next bloodmoon will rise in 7Days2Die',
+  description: 'Calculates when the next bloodmoon will rise in 7 Days to Die',
   options: [
     {
       name: 'day',


### PR DESCRIPTION
FIxes typos in the README and bloodmoon command files where 'blood moon' is spelled 'bloodmoon' and '7 Days to Die' was '7Days2Die'.