### PR TITLE
Fix: app: login before commands registered

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -21,5 +21,5 @@ function login () {
   })
 }
 
-registerCommands()
+await registerCommands()
 login()


### PR DESCRIPTION
Adds await to the call to registerCommands in app.js to allow it to finish before the client logs in. THis is so that users don't start issuing commands to the bot before it is done registering those commands in case they have changed.